### PR TITLE
Add Rails 5.2 support

### DIFF
--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.2.3'.freeze
+      VERSION = '0.3.0'.freeze
     end
   end
 end

--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'salsify_rubocop'
 
-  spec.add_dependency 'activerecord', '>= 5', '< 5.2'
+  spec.add_dependency 'activerecord', '>= 5', '< 6.0'
   spec.add_dependency 'pg', '~> 0.18'
 end

--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'salsify_rubocop'
 
-  spec.add_dependency 'activerecord', '>= 5', '< 6.0'
+  spec.add_dependency 'activerecord', '>= 5', '< 5.3'
   spec.add_dependency 'pg', '~> 0.18'
 end


### PR DESCRIPTION
Seems like per https://github.com/salsify/postgres-vacuum-monitor/blob/master/Appraisals we already test against the latest 5.x.x version of ActiveRecord. This updates the gemspec so we can use it with 5.2.

prime: @fgarces 