### PR TITLE
Report vacuum stats per distinct database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # postgres-vacuum-monitor
+## v.0.3.2
+  - Monitor non-ActiveRecord::Base database connections
+
 ## v.0.3.1
   - Relax pg requirements
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 For long running queries, the event name is `LongQueries` and the attributes are: 
 ```ruby 
 {
-  db_name: # The name of the database.
+  database_name: # The name of the database.
   start_time: # When the query started .
   running_time: # How long has it been running in seconds.
   application_name: # What's the application name that is running the query.
@@ -59,7 +59,7 @@ For auto vacuum the attributes are the following:
 
 ```ruby 
 {
-  db_name: # The name of the database.
+  database_name: # The name of the database.
   table: # Table name.
   table_size: # How big is the table.
   dead_tuples: # How many dead tuples are in the table.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ end
 For long running queries, the event name is `LongQueries` and the attributes are: 
 ```ruby 
 {
+  db_name: # The name of the database.
   start_time: # When the query started .
   running_time: # How long has it been running in seconds.
   application_name: # What's the application name that is running the query.
@@ -58,6 +59,7 @@ For auto vacuum the attributes are the following:
 
 ```ruby 
 {
+  db_name: # The name of the database.
   table: # Table name.
   table_size: # How big is the table.
   dead_tuples: # How many dead tuples are in the table.

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -7,24 +7,26 @@ module Postgres
         LONG_QUERIES = 'LongQueries'.freeze
 
         def perform(*)
-          ActiveRecord::Base.connection.execute(Postgres::Vacuum::Monitor::Query.long_running_queries).each do |row|
-            reporter_class.report_event(
-              LONG_QUERIES,
-              start_time: row['xact_start'],
-              running_time: row['seconds'],
-              application_name: row['application_name'],
-              query: row['query']
-            )
-          end
+          each_database_connection do |connection|
+            connection.execute(Postgres::Vacuum::Monitor::Query.long_running_queries).each do |row|
+              reporter_class.report_event(
+                LONG_QUERIES,
+                start_time: row['xact_start'],
+                running_time: row['seconds'],
+                application_name: row['application_name'],
+                query: row['query']
+              )
+            end
 
-          ActiveRecord::Base.connection.execute(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).each do |row|
-            reporter_class.report_event(
-              AUTOVACUUM_QUERY_EVENT,
-              table: row['relation'],
-              table_size: row['table_size'],
-              dead_tuples: row['dead_tuples'].to_i,
-              tuples_over_limit: row['dead_tuples'].to_i - row['autovacuum_vacuum_tuples'].to_i
-            )
+            connection.execute(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).each do |row|
+              reporter_class.report_event(
+                AUTOVACUUM_QUERY_EVENT,
+                table: row['relation'],
+                table_size: row['table_size'],
+                dead_tuples: row['dead_tuples'].to_i,
+                tuples_over_limit: row['dead_tuples'].to_i - row['autovacuum_vacuum_tuples'].to_i
+              )
+            end
           end
 
           true
@@ -37,6 +39,14 @@ module Postgres
           raise ConfigurationError.new('Missing or invalid report class name. Check your configuration') if @reporter_class_name.nil?
 
           @reporter_class_name
+        end
+
+        def each_database_connection
+          databases = Set.new
+          ActiveRecord::Base.connection_handler.connection_pools.map do |connection_pool|
+            db_name = connection_pool.spec.config[:database]
+            yield connection_pool.connection if databases.add?(db_name)
+          end
         end
 
         ConfigurationError = Class.new(StandardError)

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module Postgres
   module Vacuum
     module Jobs

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -11,7 +11,7 @@ module Postgres
             connection.execute(Postgres::Vacuum::Monitor::Query.long_running_queries).each do |row|
               reporter_class.report_event(
                 LONG_QUERIES,
-                db_name: name,
+                database_name: name,
                 start_time: row['xact_start'],
                 running_time: row['seconds'],
                 application_name: row['application_name'],
@@ -22,7 +22,7 @@ module Postgres
             connection.execute(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).each do |row|
               reporter_class.report_event(
                 AUTOVACUUM_QUERY_EVENT,
-                db_name: name,
+                database_name: name,
                 table: row['relation'],
                 table_size: row['table_size'],
                 dead_tuples: row['dead_tuples'].to_i,

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.3.1'.freeze
+      VERSION = '0.3.2'.freeze
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -2,8 +2,48 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
   let(:job) { Postgres::Vacuum::Jobs::MonitorJob.new }
 
   describe "#perform" do
+
+    let(:mock_connection) { double }
+    before do
+      allow(mock_connection).to receive(:execute).and_return([])
+      ActiveRecord::Base.connection_handler.connection_pools.each do |pool|
+        allow(pool).to receive(:with_connection).and_yield(mock_connection)
+      end
+    end
+
     it "finishes without exceptions." do
       expect(job.perform).to eq true
+    end
+
+    it "reports an event per query." do
+      expect(job.perform).to eq true
+      expect(mock_connection).to have_received(:execute).twice
+    end
+
+    context "with multiple connection pools" do
+
+      class SecondPool < ActiveRecord::Base
+        # might be cleaner to put this in a method if that works.  constant is weird.
+        establish_connection DB_CONFIG['test']
+      end
+
+      it "reports once for a single database." do
+        expect(job.perform).to eq true
+        expect(mock_connection).to have_received(:execute).twice
+      end
+
+      context "to different databases" do
+        let(:name_change_db_config) { { name: 'my db' } }
+
+        before do
+          allow(SecondPool.connection_pool.spec).to receive(:config).and_return(name_change_db_config)
+        end
+
+        it "reports twice for two databases" do
+          expect(job.perform).to eq true
+          expect(mock_connection).to have_received(:execute).exactly(4)
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ ActiveRecord::Base.logger = Logger.new('log/test.log')
 ActiveRecord::Base.logger.level = Logger::DEBUG
 ActiveRecord::Migration.verbose = false
 db_config = YAML.safe_load(File.read('spec/db/database.yml.travis'))
+DB_CONFIG = db_config
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
**Context**
The reporting only covers the primary (`ActiveRecord::Base`) connection.  Applications that use multiple databases want to receive statistics about their additional databases.

**Changes**
Iterate through the list of connection pools and report statistics for all unique databases by name.

Prime @fgarces 
cc @salsify/laser-viper 

**Do we want to call the new attribute `db_name`? I need to add the new attribute to the readme once we pick a name.**