### PR TITLE
Rename LongQueries event to LongTransactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # postgres-vacuum-monitor
+## v.0.5.0
+- Renamed `LongQueries` event to `LongTransactions`. 
+- Renamed `LongTransactions.query` to `LongTransactions.most_recent_query` and added a
+  transaction `state` attribute.
+
 ## v.0.4.0
   - Add rails 6 support.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Postgres::Vacuum::Monitor provides queries that provide information about the number of dead tuples and long running queries.
 This information helps to diagnose and monitor two things: 
 1) That the current auto vacuum settings are working and keeping up.
-2) That there are no long running queries affecting the auto vacuuming daemon.
+2) That there are no long running transactions affecting the auto vacuuming daemon.
 
 ## Installation
 
@@ -44,14 +44,15 @@ class MetricsReporter
 end
 ```
 
-For long running queries, the event name is `LongQueries` and the attributes are: 
+For long running transactions, the event name is `LongTransactions` and the attributes are: 
 ```ruby 
 {
   database_name: # The name of the database.
-  start_time: # When the query started .
+  start_time: # When the transaction started .
   running_time: # How long has it been running in seconds.
   application_name: # What's the application name that is running the query.
-  query: # The offending query.
+  most_recent_query: # The last query started by the transaction
+  state: # The state of the transaction - either "active" or ""
 }
 ```
 
@@ -84,9 +85,9 @@ SELECT percentile(tuples_over_limit, 95) from AutoVacuumLagging facet table wher
 ```SQL
 SELECT percentile(dead_tuples) FROM AutoVacuumLagging facet table where appName = 'my-app' SINCE 1 DAY AGO TIMESERIES
 ```     
-#### Long running queries
+#### Long running transactions
 ```SQL
-SELECT application_name, query, running_time, start_time FROM LongQueries
+SELECT application_name, state, most_recent_query, running_time, start_time FROM LongTransactions
 ```
 
 #### Tables that need to be vacuumed

--- a/lib/postgres/vacuum/monitor/query.rb
+++ b/lib/postgres/vacuum/monitor/query.rb
@@ -11,7 +11,7 @@ module Postgres
         MAX_AGE_SETTING = "'autovacuum_freeze_max_age'".freeze
         PG_CATALOG = "'pg_catalog'".freeze
 
-        def long_running_queries
+        def long_running_transactions
           <<-SQL
             SELECT *
             FROM (
@@ -20,7 +20,8 @@ module Postgres
                 xact_start,
                 EXTRACT(EPOCH FROM (now() - xact_start)) AS seconds,
                 application_name,
-                query
+                query,
+                state
               FROM pg_stat_activity
               WHERE state IN (#{STATES.join(', ')})
               ORDER BY seconds DESC

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.4.0'.freeze
+      VERSION = '0.5.0'.freeze
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -1,23 +1,69 @@
+class TestMetricsReporter
+  def self.report_event(name, attributes = {})
+
+  end
+end
+
 describe Postgres::Vacuum::Jobs::MonitorJob do
   let(:job) { Postgres::Vacuum::Jobs::MonitorJob.new }
 
   describe "#perform" do
-
     let(:mock_connection) { double }
+
     before do
       allow(mock_connection).to receive(:execute).and_return([])
       ActiveRecord::Base.connection_handler.connection_pools.each do |pool|
         allow(pool).to receive(:with_connection).and_yield(mock_connection)
       end
+
+      allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_reporter_class_name).and_return(TestMetricsReporter.name)
+      allow(TestMetricsReporter).to receive(:report_event)
     end
 
-    it "finishes without exceptions." do
-      expect(job.perform).to eq true
+    it "reports long running transaction events" do
+      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.long_running_transactions).and_return(
+        [
+          'xact_start' => 'test_xact_start',
+          'seconds' => 'test_seconds',
+          'application_name' => 'test_application_name',
+          'query' => 'test_query',
+          'state' => 'test_state'
+        ]
+      )
+
+      job.perform
+
+      expect(TestMetricsReporter).to have_received(:report_event).with(
+        Postgres::Vacuum::Jobs::MonitorJob::LONG_TRANSACTIONS,
+        database_name: 'postgres_vacuum_monitor_test',
+        start_time: 'test_xact_start',
+        running_time: 'test_seconds',
+        application_name: 'test_application_name',
+        most_recent_query: 'test_query',
+        state: 'test_state'
+      )
     end
 
-    it "reports an event per query." do
-      expect(job.perform).to eq true
-      expect(mock_connection).to have_received(:execute).twice
+    it "reports autovacuum lagging events" do
+      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).and_return(
+        [
+          'relation' => 'test_relation',
+          'table_size' => 512,
+          'dead_tuples' => 3,
+          'autovacuum_vacuum_tuples' => 1
+        ]
+      )
+
+      job.perform
+
+      expect(TestMetricsReporter).to have_received(:report_event).with(
+        Postgres::Vacuum::Jobs::MonitorJob::AUTOVACUUM_LAGGING_EVENT,
+        database_name: 'postgres_vacuum_monitor_test',
+        table: 'test_relation',
+        table_size: 512,
+        dead_tuples: 3,
+        tuples_over_limit: 2
+      )
     end
 
     context "with multiple connection pools" do
@@ -48,29 +94,9 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
   end
 
   describe "#reporter_class" do
-
     it "throws an exception without configuration" do
+      allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_reporter_class_name).and_return(nil)
       expect { job.reporter_class }.to raise_error(Postgres::Vacuum::Jobs::MonitorJob::ConfigurationError)
-    end
-
-    context "with a configuration set" do
-
-      class TestReporter
-      end
-
-      before do
-        Postgres::Vacuum::Monitor.configure do |config|
-          config.monitor_reporter_class_name = 'TestReporter'
-        end
-      end
-
-      after do
-        Postgres::Vacuum::Monitor.configure do |config|
-          config.monitor_reporter_class_name = nil
-        end
-      end
-
-      specify { expect(job.reporter_class).to eq TestReporter }
     end
   end
 end

--- a/spec/postgres/vacuum/monitor/query_spec.rb
+++ b/spec/postgres/vacuum/monitor/query_spec.rb
@@ -2,11 +2,21 @@ describe Postgres::Vacuum::Monitor::Query do
 
   describe ".long_query" do
     it "respects the time window" do
-      expect(Postgres::Vacuum::Monitor::Query.long_running_queries).to include "seconds > #{Postgres::Vacuum::Monitor::Query::TIME_LIMIT}"
+      expect(Postgres::Vacuum::Monitor::Query.long_running_transactions).to include "seconds > #{Postgres::Vacuum::Monitor::Query::TIME_LIMIT}"
     end
 
     it "respects the states" do
-      expect(Postgres::Vacuum::Monitor::Query.long_running_queries).to include "WHERE state IN (#{Postgres::Vacuum::Monitor::Query::STATES.join(', ')})"
+      expect(Postgres::Vacuum::Monitor::Query.long_running_transactions).to include "WHERE state IN (#{Postgres::Vacuum::Monitor::Query::STATES.join(', ')})"
+    end
+
+    it "generates a runnable query" do
+      ActiveRecord::Base.connection.execute(Postgres::Vacuum::Monitor::Query.long_running_transactions)
+    end
+  end
+
+  describe ".tables_eligible_vacuuming" do
+    it "generates a runnable query" do
+      ActiveRecord::Base.connection.execute(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming)
     end
   end
 end


### PR DESCRIPTION
This PR renames the `LongQueries` event to `LongTransactions` since it really corresponds to long running transactions not just long running queries. It also renames the `query` attribute to `most_recent_query` and adds a `state` attribute with the transaction state which will either be "idle in transaction" or "active". Hopefully these changes will clear up some confusion around data reported by this gem.