### PR TITLE
Capture more details in LongTransactions events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # postgres-vacuum-monitor
 ## v.0.5.0
+- Add `wait_event_type`, `transaction_id` and `min_transaction_id` to `LongTransactions` events.
+
+## v.0.5.0
 - Renamed `LongQueries` event to `LongTransactions`. 
 - Renamed `LongTransactions.query` to `LongTransactions.most_recent_query` and added a
   transaction `state` attribute.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ For long running transactions, the event name is `LongTransactions` and the attr
   running_time: # How long has it been running in seconds.
   application_name: # What's the application name that is running the query.
   most_recent_query: # The last query started by the transaction
-  state: # The state of the transaction - either "active" or ""
+  state: # The state of the transaction - either "active" or "idle in transaction"
+  wait_event_type: # The type of lock the transaction is waiting for if applicable
+  transaction_id: # The transaction_id which will be null for read-only transactions
+  min_transaction_id: # The mininum transaction id horizon
 }
 ```
 

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -16,7 +16,10 @@ module Postgres
                 running_time: row['seconds'],
                 application_name: row['application_name'],
                 most_recent_query: row['query'],
-                state: row['state']
+                state: row['state'],
+                wait_event_type: row['wait_event_type'],
+                transaction_id: row['backend_xid'],
+                min_transaction_id: row['backend_xmin']
               )
             end
 

--- a/lib/postgres/vacuum/monitor/query.rb
+++ b/lib/postgres/vacuum/monitor/query.rb
@@ -21,7 +21,10 @@ module Postgres
                 EXTRACT(EPOCH FROM (now() - xact_start)) AS seconds,
                 application_name,
                 query,
-                state
+                state,
+                backend_xid,
+                backend_xmin,
+                wait_event_type
               FROM pg_stat_activity
               WHERE state IN (#{STATES.join(', ')})
               ORDER BY seconds DESC

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.5.0'.freeze
+      VERSION = '0.6.0'.freeze
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -27,7 +27,10 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
           'seconds' => 'test_seconds',
           'application_name' => 'test_application_name',
           'query' => 'test_query',
-          'state' => 'test_state'
+          'state' => 'test_state',
+          'wait_event_type' => 'test_wait_event_type',
+          'backend_xid' => 'test_backend_xid',
+          'backend_xmin' => 'test_backend_xmin'
         ]
       )
 
@@ -40,7 +43,10 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
         running_time: 'test_seconds',
         application_name: 'test_application_name',
         most_recent_query: 'test_query',
-        state: 'test_state'
+        state: 'test_state',
+        wait_event_type: 'test_wait_event_type',
+        transaction_id: 'test_backend_xid',
+        min_transaction_id: 'test_backend_xmin'
       )
     end
 


### PR DESCRIPTION
This adds `wait_event_type`, `transaction_id` and `min_transaction_id` attributes to `LongTransactions` events which should provide better visibility into long running transactions e.g. read-only transactions vs. read-write transactions.