### PR TITLE
Lower the default long transaction threshold from 1 hour to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # postgres-vacuum-monitor
-## v.0.5.0
+## v.0.7.0
+- Lower the default `LongTransactions` threshold from 1 hour to 5 minutes and make this configurable via
+  the `long_running_transaction_threshold_seconds` setting.
+
+## v.0.6.0
 - Add `wait_event_type`, `transaction_id` and `min_transaction_id` to `LongTransactions` events.
 
 ## v.0.5.0

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The job itself needs a class to report the information and can be configured by 
 ```ruby
 Postgres::Vacuum::Monitor.configure do |config|
   config.monitor_reporter_class_name = 'MetricsReporter'
+  # Optionally change the default threshold of 5 minutes for reporting long running transactions
+  config.long_running_transaction_threshold_seconds = 10 * 60  
 end
 ```
 

--- a/lib/postgres/vacuum/configuration.rb
+++ b/lib/postgres/vacuum/configuration.rb
@@ -1,10 +1,12 @@
 module Postgres
   module Vacuum
     class Configuration
-      attr_accessor :monitor_reporter_class_name
+      DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS = 5 * 60
+      attr_accessor :monitor_reporter_class_name, :long_running_transaction_threshold_seconds
 
       def initialize
-        @monitor_reporter_class_name = nil
+        self.monitor_reporter_class_name = nil
+        self.long_running_transaction_threshold_seconds = DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS
       end
     end
   end

--- a/lib/postgres/vacuum/monitor/query.rb
+++ b/lib/postgres/vacuum/monitor/query.rb
@@ -5,7 +5,6 @@ module Postgres
         extend self
 
         STATES = ["'idle in transaction'", "'active'"].freeze
-        TIME_LIMIT = 3600
         THRESHOLD_SETTING = "'autovacuum_vacuum_threshold'".freeze
         SCALE_FACTOR_SETTING = "'autovacuum_vacuum_scale_factor'".freeze
         MAX_AGE_SETTING = "'autovacuum_freeze_max_age'".freeze
@@ -29,7 +28,7 @@ module Postgres
               WHERE state IN (#{STATES.join(', ')})
               ORDER BY seconds DESC
             ) AS long_queries
-            WHERE seconds > #{TIME_LIMIT};
+            WHERE seconds > #{Postgres::Vacuum::Monitor.configuration.long_running_transaction_threshold_seconds};
           SQL
         end
 

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.6.0'.freeze
+      VERSION = '0.7.0'.freeze
     end
   end
 end

--- a/spec/postgres/vacuum/monitor/query_spec.rb
+++ b/spec/postgres/vacuum/monitor/query_spec.rb
@@ -2,7 +2,7 @@ describe Postgres::Vacuum::Monitor::Query do
 
   describe ".long_query" do
     it "respects the time window" do
-      expect(Postgres::Vacuum::Monitor::Query.long_running_transactions).to include "seconds > #{Postgres::Vacuum::Monitor::Query::TIME_LIMIT}"
+      expect(Postgres::Vacuum::Monitor::Query.long_running_transactions).to include "seconds > #{Postgres::Vacuum::Monitor.configuration.long_running_transaction_threshold_seconds}"
     end
 
     it "respects the states" do


### PR DESCRIPTION
This also makes the threshold configurable.