### PR TITLE
Add connection monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # postgres-vacuum-monitor
 
-## v.0.8.0
+## v.10.0
+- Add events for connection idle time and state.
+
+## v.0.9.0
 - Add the application name in the event.
 
 ## v.0.8.0

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.9.0'.freeze
+      VERSION = '0.10.0'.freeze
     end
   end
 end


### PR DESCRIPTION
I started investigating what would make use a connection pooler and noticed that we don't have a lot of metrics that could tell us how much time the connections are in an idle state. Pganalyze samples every 10 minutes but I would like to be a bit more aggressive than that and see the time in idle state.

@cjf2xn you are prime.