### PR TITLE
Update rake 12.3.3

### DIFF
--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls_reborn', '>= 0.18.0'
   spec.add_development_dependency 'database_cleaner'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'salsify_rubocop'
 


### PR DESCRIPTION
The version of rake we are using has a [security vulnerability](https://github.com/advisories/GHSA-jppv-gw3r-w3q8). Update to the latest

@cjf2xn you are prime