### PR TITLE
Fix the connection state query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # postgres-vacuum-monitor
 
+## v.10.1
+- Query bug fix.
+
 ## v.10.0
 - Add events for connection idle time and state.
 

--- a/lib/postgres/vacuum/monitor/query.rb
+++ b/lib/postgres/vacuum/monitor/query.rb
@@ -104,7 +104,7 @@ module Postgres
               state, count(*) as connection_count 
             FROM pg_stat_activity 
             GROUP BY state 
-            ORDER BY count DESC;
+            ORDER BY connection_count DESC;
           SQL
         end
 

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -1,7 +1,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.10.0'.freeze
+      VERSION = '0.10.1'.freeze
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -8,149 +8,162 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
   let(:job) { Postgres::Vacuum::Jobs::MonitorJob.new }
 
   describe "#perform" do
-    let(:mock_connection) { double }
 
-    before do
-      allow(mock_connection).to receive(:execute).and_return([])
-      ActiveRecord::Base.connection_handler.connection_pools.each do |pool|
-        allow(pool).to receive(:with_connection).and_yield(mock_connection)
+    context "without a mocked connection" do
+      before do
+        allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_reporter_class_name).and_return(TestMetricsReporter.name)
       end
 
-      allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_reporter_class_name).and_return(TestMetricsReporter.name)
-      allow(TestMetricsReporter).to receive(:report_event)
-    end
-
-    it "reports long running transaction events" do
-      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.long_running_transactions).and_return(
-        [
-          'xact_start' => 'test_xact_start',
-          'seconds' => 'test_seconds',
-          'application_name' => 'test_application_name',
-          'query' => 'test_query',
-          'state' => 'test_state',
-          'wait_event_type' => 'test_wait_event_type',
-          'backend_xid' => 'test_backend_xid',
-          'backend_xmin' => 'test_backend_xmin'
-        ]
-      )
-
-      job.perform
-
-      expect(TestMetricsReporter).to have_received(:report_event).with(
-        Postgres::Vacuum::Jobs::MonitorJob::LONG_TRANSACTIONS,
-        database_name: 'postgres_vacuum_monitor_test',
-        start_time: 'test_xact_start',
-        running_time: 'test_seconds',
-        application_name: 'test_application_name',
-        most_recent_query: 'test_query',
-        state: 'test_state',
-        wait_event_type: 'test_wait_event_type',
-        transaction_id: 'test_backend_xid',
-        min_transaction_id: 'test_backend_xmin'
-      )
-    end
-
-    it "reports autovacuum lagging events" do
-      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).and_return(
-        [
-          'relation' => 'test_relation',
-          'table_size' => 512,
-          'dead_tuples' => 3,
-          'autovacuum_vacuum_tuples' => 1
-        ]
-      )
-
-      job.perform
-
-      expect(TestMetricsReporter).to have_received(:report_event).with(
-        Postgres::Vacuum::Jobs::MonitorJob::AUTOVACUUM_LAGGING_EVENT,
-        database_name: 'postgres_vacuum_monitor_test',
-        table: 'test_relation',
-        table_size: 512,
-        dead_tuples: 3,
-        tuples_over_limit: 2
-      )
-    end
-
-    it "reports blocked queries" do
-      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.blocked_queries).and_return(
-        [
-          'blocked_pid' => 2,
-          'blocked_application' => 'foo',
-          'blocked_statement' => 'SELECT 1 FROM products',
-          'blocking_pid' => 3,
-          'blocking_application' => 'bar',
-          'current_statement_in_blocking_process' => 'SELECT 2 FROM products'
-        ]
-      )
-
-      job.perform
-
-      expect(TestMetricsReporter).to have_received(:report_event).with(
-        Postgres::Vacuum::Jobs::MonitorJob::BLOCKED_QUERIES,
-        database_name: 'postgres_vacuum_monitor_test',
-        blocked_application: 'foo',
-        blocked_pid: 2,
-        blocked_statement: 'SELECT 1 FROM products',
-        blocking_pid: 3,
-        blocking_application: 'bar',
-        current_statement_in_blocking_process: 'SELECT 2 FROM products'
-      )
-    end
-
-    it "reports connection state" do
-      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.connection_state).and_return(
-        ['connection_count' => 4, 'state' => 'idle']
-      )
-
-      job.perform
-
-      expect(TestMetricsReporter).to have_received(:report_event).with(
-        Postgres::Vacuum::Jobs::MonitorJob::CONNECTION_STATE,
-        database_name: 'postgres_vacuum_monitor_test',
-        connection_count: 4,
-        state: 'idle'
-      )
-    end
-
-    it "reports connection idle time" do
-      allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.connection_idle_time).and_return(
-        ['max' => 3.1, 'median' => 222.22, 'percentile_90' => 9323.323]
-      )
-
-      job.perform
-
-      expect(TestMetricsReporter).to have_received(:report_event).with(
-        Postgres::Vacuum::Jobs::MonitorJob::CONNECTION_IDLE_TIME,
-        database_name: 'postgres_vacuum_monitor_test',
-        max: 3.1,
-        median: 222.22,
-        percentile_90: 9323.323
-      )
-    end
-
-    context "with multiple connection pools" do
-
-      class SecondPool < ActiveRecord::Base
-        # might be cleaner to put this in a method if that works.  constant is weird.
-        establish_connection DB_CONFIG['test']
-      end
-
-      it "reports once for a single database." do
+      it "executes all the queries" do
         expect(job.perform).to eq true
-        expect(mock_connection).to have_received(:execute).exactly(5)
       end
+    end
 
-      context "to different databases" do
-        let(:name_change_db_config) { { name: 'my db' } }
+    context "with a mocked connection" do
+      let(:mock_connection) { double }
 
-        before do
-          allow(SecondPool.connection_pool.spec).to receive(:config).and_return(name_change_db_config)
+      before do
+        allow(mock_connection).to receive(:execute).and_return([])
+        ActiveRecord::Base.connection_handler.connection_pools.each do |pool|
+          allow(pool).to receive(:with_connection).and_yield(mock_connection)
         end
 
-        it "reports twice for two databases" do
+        allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_reporter_class_name).and_return(TestMetricsReporter.name)
+        allow(TestMetricsReporter).to receive(:report_event)
+      end
+
+      it "reports long running transaction events" do
+        allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.long_running_transactions).and_return(
+          [
+            'xact_start' => 'test_xact_start',
+            'seconds' => 'test_seconds',
+            'application_name' => 'test_application_name',
+            'query' => 'test_query',
+            'state' => 'test_state',
+            'wait_event_type' => 'test_wait_event_type',
+            'backend_xid' => 'test_backend_xid',
+            'backend_xmin' => 'test_backend_xmin'
+          ]
+        )
+
+        job.perform
+
+        expect(TestMetricsReporter).to have_received(:report_event).with(
+          Postgres::Vacuum::Jobs::MonitorJob::LONG_TRANSACTIONS,
+          database_name: 'postgres_vacuum_monitor_test',
+          start_time: 'test_xact_start',
+          running_time: 'test_seconds',
+          application_name: 'test_application_name',
+          most_recent_query: 'test_query',
+          state: 'test_state',
+          wait_event_type: 'test_wait_event_type',
+          transaction_id: 'test_backend_xid',
+          min_transaction_id: 'test_backend_xmin'
+        )
+      end
+
+      it "reports autovacuum lagging events" do
+        allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.tables_eligible_vacuuming).and_return(
+          [
+            'relation' => 'test_relation',
+            'table_size' => 512,
+            'dead_tuples' => 3,
+            'autovacuum_vacuum_tuples' => 1
+          ]
+        )
+
+        job.perform
+
+        expect(TestMetricsReporter).to have_received(:report_event).with(
+          Postgres::Vacuum::Jobs::MonitorJob::AUTOVACUUM_LAGGING_EVENT,
+          database_name: 'postgres_vacuum_monitor_test',
+          table: 'test_relation',
+          table_size: 512,
+          dead_tuples: 3,
+          tuples_over_limit: 2
+        )
+      end
+
+      it "reports blocked queries" do
+        allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.blocked_queries).and_return(
+          [
+            'blocked_pid' => 2,
+            'blocked_application' => 'foo',
+            'blocked_statement' => 'SELECT 1 FROM products',
+            'blocking_pid' => 3,
+            'blocking_application' => 'bar',
+            'current_statement_in_blocking_process' => 'SELECT 2 FROM products'
+          ]
+        )
+
+        job.perform
+
+        expect(TestMetricsReporter).to have_received(:report_event).with(
+          Postgres::Vacuum::Jobs::MonitorJob::BLOCKED_QUERIES,
+          database_name: 'postgres_vacuum_monitor_test',
+          blocked_application: 'foo',
+          blocked_pid: 2,
+          blocked_statement: 'SELECT 1 FROM products',
+          blocking_pid: 3,
+          blocking_application: 'bar',
+          current_statement_in_blocking_process: 'SELECT 2 FROM products'
+        )
+      end
+
+      it "reports connection state" do
+        allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.connection_state).and_return(
+          ['connection_count' => 4, 'state' => 'idle']
+        )
+
+        job.perform
+
+        expect(TestMetricsReporter).to have_received(:report_event).with(
+          Postgres::Vacuum::Jobs::MonitorJob::CONNECTION_STATE,
+          database_name: 'postgres_vacuum_monitor_test',
+          connection_count: 4,
+          state: 'idle'
+        )
+      end
+
+      it "reports connection idle time" do
+        allow(mock_connection).to receive(:execute).with(Postgres::Vacuum::Monitor::Query.connection_idle_time).and_return(
+          ['max' => 3.1, 'median' => 222.22, 'percentile_90' => 9323.323]
+        )
+
+        job.perform
+
+        expect(TestMetricsReporter).to have_received(:report_event).with(
+          Postgres::Vacuum::Jobs::MonitorJob::CONNECTION_IDLE_TIME,
+          database_name: 'postgres_vacuum_monitor_test',
+          max: 3.1,
+          median: 222.22,
+          percentile_90: 9323.323
+        )
+      end
+
+      context "with multiple connection pools" do
+
+        class SecondPool < ActiveRecord::Base
+          # might be cleaner to put this in a method if that works.  constant is weird.
+          establish_connection DB_CONFIG['test']
+        end
+
+        it "reports once for a single database." do
           expect(job.perform).to eq true
-          expect(mock_connection).to have_received(:execute).exactly(10)
+          expect(mock_connection).to have_received(:execute).exactly(5)
+        end
+
+        context "to different databases" do
+          let(:name_change_db_config) { { name: 'my db' } }
+
+          before do
+            allow(SecondPool.connection_pool.spec).to receive(:config).and_return(name_change_db_config)
+          end
+
+          it "reports twice for two databases" do
+            expect(job.perform).to eq true
+            expect(mock_connection).to have_received(:execute).exactly(10)
+          end
         end
       end
     end


### PR DESCRIPTION
I renamed the column but didnt change the group section. I added a test to run the queries in the DB instead of mocking the connection.

@stanleyyamane you are prime