### PR TITLE
Add ruby 3 support and drop ruby < 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,5 +94,5 @@ workflows:
                 - "2.7.2"
                 - "3.0.0"
             exclude:
-              - gemfile: "gemfiles/rails_5.2.gemfile"
+              - gemfile: "gemfiles/activerecord_5_2.gemfile"
                 ruby_version: "3.0.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           command: dockerize -wait tcp://localhost:5432 -timeout 60s
       - run:
           name: Wait for Database User
-          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U ubuntu -d circle_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
+          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U ubuntu -d postgres_vacuum_monitor_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:2.6.6
     working_directory: ~/postgres-vacuum-monitor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.5.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.5.8-
+            - v1-gems-ruby-2.6.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.6.6-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.5.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.6.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -29,8 +29,10 @@ jobs:
     parameters:
       gemfile:
         type: string
+      ruby_version:
+        type: string
     docker:
-      - image: salsify/ruby_ci:2.5.8
+      - image: salsify/ruby_ci:<< parameters.ruby_version >>
         environment:
           TEST_DATABASE_URL: postgresql://circleci@localhost/circle_test
       - image: circleci/postgres:9.6
@@ -50,8 +52,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.5.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
-            - v1-gems-ruby-2.5.8-
+            - v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+            - v1-gems-ruby-<< parameters.ruby_version >>-
       - run:
           name: Install Gems
           command: |
@@ -60,10 +62,16 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.5.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
+          key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
+      - run:
+          name: Wait for Database
+          command: dockerize -wait tcp://localhost:5432 -timeout 60s
+      - run:
+          name: Wait for Database User
+          command: t=30; for i in `seq $t`; do psql -h localhost -p 5432 -U ubuntu -d circle_test -c '\q' && break; [ $i -eq $t ] && return 2; sleep 1; done;
       - run:
           name: Run Tests
           command: |
@@ -81,3 +89,10 @@ workflows:
                 - "gemfiles/activerecord_5_2.gemfile"
                 - "gemfiles/activerecord_6_0.gemfile"
                 - "gemfiles/activerecord_6_1.gemfile"
+              ruby_version:
+                - "2.6.6"
+                - "2.7.2"
+                - "3.0.0"
+            exclude:
+              - gemfile: "gemfiles/rails_5.2.gemfile"
+                ruby_version: "3.0.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.6
+      - image: salsify/ruby_ci:2.7.2
     working_directory: ~/postgres-vacuum-monitor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.6.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.6.6-
+            - v1-gems-ruby-2.7.2-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.7.2-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.6.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.7.2-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop_rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # postgres-vacuum-monitor
+## v.12.0
+- Add support for ruby 3
+- Drop support for ruby < 2.6
 
 ## v.11.0
 - Add support for rails 6.1

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.11.0'
+      VERSION = '0.12.0'
     end
   end
 end

--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Added ruby 3 to the test matrix and it passed with no changes
Require ruby >= 2.6 since 2.5 is nearly EOL.

prime: @fgarces 
cc: @salsify/laser-viper 