### PR TITLE
Coerces long transaction duration to an integer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,11 @@ jobs:
         type: string
       ruby_version:
         type: string
+      postgres_version:
+        type: string
     docker:
       - image: salsify/ruby_ci:<< parameters.ruby_version >>
-      - image: circleci/postgres:12.9
+      - image: cimg/postgres:<< parameters.postgres_version >>
         environment:
           POSTGRES_USER: "circleci"
           POSTGRES_DB: "circle_test"
@@ -92,3 +94,6 @@ workflows:
                 - "3.0.5"
                 - "3.1.3"
                 - "3.2.0"
+              postgres_version:
+                - "12.9"
+                - "14.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # postgres-vacuum-monitor
 
+## v0.13.1
+- Fix long running transaction duration reporting in Postgres 14
+
 ## v0.13.0
 - Add support for ruby 3.2 and Rails 7.0
 - Drop support for ruby < 2.7 and Rails < 6.0.
@@ -31,7 +34,7 @@
 - Add `wait_event_type`, `transaction_id` and `min_transaction_id` to `LongTransactions` events.
 
 ## v.0.5.0
-- Renamed `LongQueries` event to `LongTransactions`. 
+- Renamed `LongQueries` event to `LongTransactions`.
 - Renamed `LongTransactions.query` to `LongTransactions.most_recent_query` and added a
   transaction `state` attribute.
 
@@ -43,4 +46,3 @@
 
 ## v.0.3.1
   - Relax pg requirements
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # postgres-vacuum-monitor
 
 ## v0.13.1
-- Fix long running transaction duration reporting in Postgres 14
+- Fix epoch reporting in Postgres 14
 
 ## v0.13.0
 - Add support for ruby 3.2 and Rails 7.0

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -18,7 +18,7 @@ module Postgres
                 LONG_TRANSACTIONS,
                 database_name: name,
                 start_time: row['xact_start'],
-                running_time: row['seconds'],
+                running_time: row['seconds'].to_i,
                 application_name: row['application_name'],
                 most_recent_query: row['query'],
                 state: row['state'],

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -65,9 +65,9 @@ module Postgres
               reporter_class.report_event(
                 CONNECTION_IDLE_TIME,
                 database_name: name,
-                max: row['max'],
-                median: row['median'],
-                percentile_90: row['percentile_90']
+                max: row['max'].to_i,
+                median: row['median'].to_i,
+                percentile_90: row['percentile_90'].to_i
               )
             end
           end

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.13.0'
+      VERSION = '0.13.1'
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -41,7 +41,7 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
                                                    .and_return(
                                                      [
                                                        'xact_start' => 'test_xact_start',
-                                                       'seconds' => 'test_seconds',
+                                                       'seconds' => 60.00,
                                                        'application_name' => 'test_application_name',
                                                        'query' => 'test_query',
                                                          'state' => 'test_state',
@@ -57,7 +57,7 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
           Postgres::Vacuum::Jobs::MonitorJob::LONG_TRANSACTIONS,
           database_name: 'postgres_vacuum_monitor_test',
           start_time: 'test_xact_start',
-          running_time: 'test_seconds',
+          running_time: 60,
           application_name: 'test_application_name',
           most_recent_query: 'test_query',
           state: 'test_state',


### PR DESCRIPTION
Posgres 14 appears to have improved the precision of `epoch` values to [6 decimal places](https://www.postgresql.org/docs/14/functions-datetime.html), compared to [previous versions](https://www.postgresql.org/docs/12/functions-datetime.html) which only conditionally captured as many as 2 decimal places. Our metrics reporter cannot handle this level of precision however, so since the upgrade to Postgres 14 all of our `running_time` metrics reported under the `LongTransactions` event appear as some `#<BigDecimal>` string. 

This change simply coerces the `epoch` calculation back to an integer, which should fix our metrics. 

prime: @fgarces 
cc: @salsify/laser-viper 