### PR TITLE
Drop support for ruby < 3.0 and Rails < 6.1, uses ECR images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,15 @@
+# YAML Anchors
+aws-auth: &aws-auth
+  aws_auth:
+    aws_access_key_id: $ECR_AWS_ACCESS_KEY_ID
+    aws_secret_access_key: $ECR_AWS_SECRET_ACCESS_KEY
+
 version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.7.7
+      - image: $SALSIFY_ECR_REPO/ruby_ci:2.7.7
+        <<: *aws-auth
     working_directory: ~/postgres-vacuum-monitor
     steps:
       - checkout
@@ -34,7 +41,8 @@ jobs:
       postgres_version:
         type: string
     docker:
-      - image: salsify/ruby_ci:<< parameters.ruby_version >>
+      - image: $SALSIFY_ECR_REPO/ruby_ci:<< parameters.ruby_version >>
+        <<: *aws-auth
       - image: cimg/postgres:<< parameters.postgres_version >>
         environment:
           POSTGRES_USER: "circleci"
@@ -81,16 +89,16 @@ jobs:
 workflows:
   build:
     jobs:
-      - lint
+      - lint:
+          context: Salsify
       - test:
+          context: Salsify
           matrix:
             parameters:
               gemfile:
-                - "gemfiles/activerecord_6_0.gemfile"
                 - "gemfiles/activerecord_6_1.gemfile"
                 - "gemfiles/activerecord_7_0.gemfile"
               ruby_version:
-                - "2.7.7"
                 - "3.0.5"
                 - "3.1.3"
                 - "3.2.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,9 @@ workflows:
                 - "gemfiles/activerecord_6_1.gemfile"
                 - "gemfiles/activerecord_7_0.gemfile"
               ruby_version:
-                - "3.0.5"
-                - "3.1.3"
-                - "3.2.0"
+                - "3.0.6"
+                - "3.1.4"
+                - "3.2.2"
               postgres_version:
                 - "12.9"
                 - "14.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,15 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: $SALSIFY_ECR_REPO/ruby_ci:2.7.7
+      - image: $SALSIFY_ECR_REPO/ruby_ci:3.0.6
         <<: *aws-auth
     working_directory: ~/postgres-vacuum-monitor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.7.7-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.7.7-
+            - v1-gems-ruby-3.0.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-3.0.6-
       - run:
           name: Install Gems
           command: |
@@ -25,7 +25,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.7.7-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-3.0.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop_rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # postgres-vacuum-monitor
 
+## v0.14.0
+- Drop support for ruby < 3.0 and Rails < 6.1
+
 ## v0.13.1
 - Fix epoch reporting in Postgres 14
 

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.13.1'
+      VERSION = '0.14.0'
     end
   end
 end

--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Following up from our discussion in https://github.com/salsify/postgres-vacuum-monitor/pull/22, this removes ruby 2.7.7 and Rails 6.0 from the test matrix then updates our ruby images to their ECR counterparts. We only have the latest patch versions in ECR so I had to bump those too. 

prime: @fgarces 
cc: @salsify/laser-viper 