### PR TITLE
Requires activerecord >= 6.1

### DIFF
--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.42.1'
 
-  spec.add_dependency 'activerecord', '>= 6.0', '< 7.1'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 7.1'
   spec.add_dependency 'pg', '>= 0.18', '< 2.0'
 end


### PR DESCRIPTION
In my haste, I merged [version 0.14.0 which dropped support for Rails 6.0](https://github.com/salsify/postgres-vacuum-monitor/pull/23) but I forgot to also raise the minimum required version of activerecord to 6.1. This fixes the version dependency on activerecord. 

I figure this isn't worth another patch version, if that's true then I'll yank the bad version before re-release.

prime: @fgarces 
cc: @gremerritt 