### PR TITLE
Requires activerecord >= 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # postgres-vacuum-monitor
 
+## v0.14.1
+- Requires activerecord >= 6.1
+
 ## v0.14.0
 - Drop support for ruby < 3.0 and Rails < 6.1
 

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.14.0'
+      VERSION = '0.14.1'
     end
   end
 end


### PR DESCRIPTION
In [0.14.0](https://github.com/salsify/postgres-vacuum-monitor/pull/23) I dropped support for Rails < 6.1, but forgot to actually update the pinned version of activerecord until https://github.com/salsify/postgres-vacuum-monitor/pull/24. Rather than yanking the last version, release 0.14.1 with this fix. 

prime: @fgarces
cc: @gremerritt