### PR TITLE
Tune job attempts and max run time [PIMCORE-186]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # postgres-vacuum-monitor
 
+## v0.16.0
+- Add `max_attempts` and `max_run_time` to `Postgres::Vacuum::Jobs::MonitorJob` to avoid backing up the queue. The
+  defaults are 1 attempt and 10 seconds, but they can be configured with `monitor_max_attempts` and
+  `monitor_max_run_time_seconds`, respectively.
+
 ## v0.15.0
 - Add support for Rails 7.1
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ The job itself needs a class to report the information and can be configured by 
 Postgres::Vacuum::Monitor.configure do |config|
   config.monitor_reporter_class_name = 'MetricsReporter'
   # Optionally change the default threshold of 5 minutes for reporting long running transactions
-  config.long_running_transaction_threshold_seconds = 10 * 60  
+  config.long_running_transaction_threshold_seconds = 10 * 60
+  # Optionally change `max_attempts` of the monitor job (default 1)
+  config.monitor_max_attempts = 3
+  # Optionally change `max_run_time` of the monitor job (default 10 seconds)
+  config.monitor_max_run_time_seconds = 5
 end
 ```
 

--- a/lib/postgres/vacuum/configuration.rb
+++ b/lib/postgres/vacuum/configuration.rb
@@ -4,11 +4,19 @@ module Postgres
   module Vacuum
     class Configuration
       DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS = 5 * 60
-      attr_accessor :monitor_reporter_class_name, :long_running_transaction_threshold_seconds
+      DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS = 10
+      DEFAULT_MONITOR_MAX_ATTEMPTS = 1
+
+      attr_accessor :monitor_reporter_class_name,
+                    :long_running_transaction_threshold_seconds,
+                    :monitor_max_run_time_seconds,
+                    :monitor_max_attempts
 
       def initialize
         self.monitor_reporter_class_name = nil
         self.long_running_transaction_threshold_seconds = DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS
+        self.monitor_max_run_time_seconds = DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS
+        self.monitor_max_attempts = DEFAULT_MONITOR_MAX_ATTEMPTS
       end
     end
   end

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -11,6 +11,14 @@ module Postgres
         CONNECTION_STATE = 'ConnectionState'
         CONNECTION_IDLE_TIME = 'ConnectionIdleTime'
 
+        def max_run_time
+          Postgres::Vacuum::Monitor.configuration.monitor_max_run_time_seconds.seconds
+        end
+
+        def max_attempts
+          Postgres::Vacuum::Monitor.configuration.monitor_max_attempts
+        end
+
         def perform(*)
           with_each_db_name_and_connection do |name, connection|
             connection.execute(Postgres::Vacuum::Monitor::Query.long_running_transactions).each do |row|

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.15.0'
+      VERSION = '0.16.0'
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -194,4 +194,40 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
       expect { job.reporter_class }.to raise_error(Postgres::Vacuum::Jobs::MonitorJob::ConfigurationError)
     end
   end
+
+  describe "#max_attempts" do
+    context "with default configuration" do
+      it "makes 1 attempt" do
+        expect(job.max_attempts).to eq(1)
+      end
+    end
+
+    context "with custom configuration" do
+      before do
+        allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_max_attempts).and_return(3)
+      end
+
+      it "makes the configured number for attempts" do
+        expect(job.max_attempts).to eq(3)
+      end
+    end
+  end
+
+  describe "#max_run_time" do
+    context "with default configuration" do
+      it "times out after 10 seconds" do
+        expect(job.max_run_time).to eq(10.seconds)
+      end
+    end
+
+    context "with custom configuration" do
+      before do
+        allow(Postgres::Vacuum::Monitor.configuration).to receive(:monitor_max_run_time_seconds).and_return(60)
+      end
+
+      it "times out after the configured number of seconds" do
+        expect(job.max_run_time).to eq(60.seconds)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Since we run the `Postgres::Vacuum::Jobs::MonitorJob` frequently, if the Postgres queries to fetch the metrics become slow (we saw them take up to 5 minutes at one point), we can start queuing and running more of these jobs than we can complete putting even more pressure on the database.

## Solution

This PR makes it so that, by default, the monitor job will timeout after 10 seconds and only make a single attempt to ensure we don't get a backlog of these jobs.

prime: @broels 
cc: @salsify/pim-core-backend 

[PIMCORE-186]

[PIMCORE-186]: https://salsify.atlassian.net/browse/PIMCORE-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ