### PR TITLE
Fix issue causing duplicate release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@
 
 require 'bundler/gem_tasks'
 require 'bundler/setup'
-Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |task|


### PR DESCRIPTION
This appears to be causing the issue where the gem is released twice, thus failing our pipeline but still successfully releasing the gem.

You can see in the first output below it builds and tags twice (and tries to push the first time and fails since I don't pass creds). In the second output this no longer happens.
```
postgres-vacuum-monitor on  master via  v3.1.3 took 5s
❯ be rake release
postgres-vacuum-monitor 0.16.0 built to pkg/postgres-vacuum-monitor-0.16.0.gem.
postgres-vacuum-monitor 0.16.0 built to pkg/postgres-vacuum-monitor-0.16.0.gem.
Tag v0.16.0 has already been created.
Tag v0.16.0 has already been created.
Enter your RubyGems.org credentials.
Don't have an account yet? Create one at https://rubygems.org/sign_up
   Email:   ^CERROR:  Interrupted
rake aborted!
Interrupt:
/Users/jbranham/.rbenv/versions/3.1.3/bin/bundle:25:in `load'
/Users/jbranham/.rbenv/versions/3.1.3/bin/bundle:25:in `<main>'
Tasks: TOP => release => release:rubygem_push
(See full trace by running task with --trace)

postgres-vacuum-monitor on  master via  v3.1.3 took 4s
❯ vim Rakefile

postgres-vacuum-monitor on  master [!] via  v3.1.3 took 2s
❯ be rake release
postgres-vacuum-monitor 0.16.0 built to pkg/postgres-vacuum-monitor-0.16.0.gem.
rake aborted!
There are files that need to be committed first.
/Users/jbranham/.rbenv/versions/3.1.3/bin/bundle:25:in `load'
/Users/jbranham/.rbenv/versions/3.1.3/bin/bundle:25:in `<main>'
Tasks: TOP => release => release:guard_clean
(See full trace by running task with --trace)
```

prime @erikkessler1 