### PR TITLE
Add a statement timeout to monitor queries [PIMCORE-485]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # postgres-vacuum-monitor
 
+## v0.17.0
+- Increased default `monitor_max_run_time_seconds` to 60 seconds.
+- Added `monitor_statement_timeout_seconds` (defaults to 10 seconds) to limit query runtime.
+- Eagerly clear connection pools when`ActiveRecord::StatementInvalid` is encounted to attempt
+  to clear bad connections.
+
 ## v0.16.0
 - Add `max_attempts` and `max_run_time` to `Postgres::Vacuum::Jobs::MonitorJob` to avoid backing up the queue. The
   defaults are 1 attempt and 10 seconds, but they can be configured with `monitor_max_attempts` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.17.0
 - Increased default `monitor_max_run_time_seconds` to 60 seconds.
 - Added `monitor_statement_timeout_seconds` (defaults to 10 seconds) to limit query runtime.
-- Eagerly clear connection pools when`ActiveRecord::StatementInvalid` is encounted to attempt
-  to clear bad connections.
+- Eagerly clear connection pools when a `ActiveRecord::StatementInvalid` or `ActiveRecord::ConnectionTimeoutError`
+  is encountered to attempt to clear bad connections.
 
 ## v0.16.0
 - Add `max_attempts` and `max_run_time` to `Postgres::Vacuum::Jobs::MonitorJob` to avoid backing up the queue. The

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Postgres::Vacuum::Monitor.configure do |config|
   config.long_running_transaction_threshold_seconds = 10 * 60
   # Optionally change `max_attempts` of the monitor job (default 1)
   config.monitor_max_attempts = 3
-  # Optionally change `max_run_time` of the monitor job (default 10 seconds)
+  # Optionally change `max_run_time` of the monitor job (default 60 seconds)
   config.monitor_max_run_time_seconds = 5
 end
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Postgres::Vacuum::Monitor.configure do |config|
   config.monitor_max_attempts = 3
   # Optionally change `max_run_time` of the monitor job (default 60 seconds)
   config.monitor_max_run_time_seconds = 5
+  # Optionally change the statement timeout of queries (default 10 seconds)
+  config.monitor_statement_timeout_seconds = 5
 end
 ```
 

--- a/lib/postgres/vacuum/configuration.rb
+++ b/lib/postgres/vacuum/configuration.rb
@@ -6,17 +6,20 @@ module Postgres
       DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS = 5 * 60
       DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS = 60
       DEFAULT_MONITOR_MAX_ATTEMPTS = 1
+      DEFAULT_MONITOR_STATEMENT_TIMEOUT_SECONDS = 10
 
       attr_accessor :monitor_reporter_class_name,
                     :long_running_transaction_threshold_seconds,
                     :monitor_max_run_time_seconds,
-                    :monitor_max_attempts
+                    :monitor_max_attempts,
+                    :monitor_statement_timeout_seconds
 
       def initialize
         self.monitor_reporter_class_name = nil
         self.long_running_transaction_threshold_seconds = DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS
         self.monitor_max_run_time_seconds = DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS
         self.monitor_max_attempts = DEFAULT_MONITOR_MAX_ATTEMPTS
+        self.monitor_statement_timeout_seconds = DEFAULT_MONITOR_STATEMENT_TIMEOUT_SECONDS
       end
     end
   end

--- a/lib/postgres/vacuum/configuration.rb
+++ b/lib/postgres/vacuum/configuration.rb
@@ -4,7 +4,7 @@ module Postgres
   module Vacuum
     class Configuration
       DEFAULT_LONG_RUNNING_TRANSACTION_THRESHOLD_SECONDS = 5 * 60
-      DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS = 10
+      DEFAULT_MONITOR_MAX_RUN_TIME_SECONDS = 60
       DEFAULT_MONITOR_MAX_ATTEMPTS = 1
 
       attr_accessor :monitor_reporter_class_name,

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -114,7 +114,7 @@ module Postgres
 
           # We want to avoid hanging onto a bad connection that would cause all future
           # jobs to fail, so we eagerly clear the pool.
-          rescue ActiveRecord::StatementInvalid
+          rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionTimeoutError
             connection_pool.disconnect!
             raise
           end
@@ -126,7 +126,8 @@ module Postgres
         end
 
         def set_statement_timeout(connection, timeout)
-          connection.execute("SET statement_timeout = '#{timeout}'")
+          query = ActiveRecord::Base.sanitize_sql(['SET statement_timeout = ?', timeout])
+          connection.execute(query)
         end
 
         def configured_timeout_seconds

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -112,6 +112,11 @@ module Postgres
               set_statement_timeout(connection, original_timeout)
             end
 
+          # We want to avoid hanging onto a bad connection that would cause all future
+          # jobs to fail, so we eagerly clear the pool.
+          rescue ActiveRecord::StatementInvalid
+            connection_pool.disconnect!
+            raise
           end
         end
 

--- a/lib/postgres/vacuum/jobs/monitor_job.rb
+++ b/lib/postgres/vacuum/jobs/monitor_job.rb
@@ -98,12 +98,34 @@ module Postgres
           databases = Set.new
           ActiveRecord::Base.connection_handler.connection_pools.map do |connection_pool|
             db_name = connection_pool.db_config.configuration_hash[:database]
+            next unless databases.add?(db_name)
 
-            # activerecord allocates a connection pool per call to establish_connection
-            # multiple pools might interact with the same database so we use the
-            # database name to dedup
-            connection_pool.with_connection { |conn| yield(db_name, conn) } if databases.add?(db_name)
+            # ActiveRecord allocates a connection pool per call to `.establish_connection`
+            # As a result, multiple pools might interact with the same database, so we use
+            # the database name to dedupe.
+            connection_pool.with_connection do |connection|
+              original_timeout = statement_timeout(connection)
+              set_statement_timeout(connection, "#{configured_timeout_seconds}s")
+
+              yield(db_name, connection)
+            ensure
+              set_statement_timeout(connection, original_timeout)
+            end
+
           end
+        end
+
+        def statement_timeout(connection)
+          result = connection.execute('SHOW statement_timeout').first
+          result['statement_timeout'] if result.present?
+        end
+
+        def set_statement_timeout(connection, timeout)
+          connection.execute("SET statement_timeout = '#{timeout}'")
+        end
+
+        def configured_timeout_seconds
+          Postgres::Vacuum::Monitor.configuration.monitor_statement_timeout_seconds
         end
 
         ConfigurationError = Class.new(StandardError)

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.16.0'
+      VERSION = '0.17.0'
     end
   end
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -168,7 +168,7 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
 
         it "reports once for a single database." do
           expect(job.perform).to eq true
-          expect(mock_connection).to have_received(:execute).exactly(5)
+          expect(mock_connection).to have_received(:execute).exactly(8)
         end
 
         context "to different databases" do
@@ -181,8 +181,20 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
 
           it "reports twice for two databases" do
             expect(job.perform).to eq true
-            expect(mock_connection).to have_received(:execute).exactly(10)
+            expect(mock_connection).to have_received(:execute).exactly(16)
           end
+        end
+      end
+
+      describe "statement timeouts" do
+        it "sets and restored statement timeout" do
+          original_timeout = [{ 'statement_timeout' => '20m' }]
+          allow(mock_connection).to receive(:execute).with('SHOW statement_timeout').and_return(original_timeout)
+
+          job.perform
+
+          expect(mock_connection).to have_received(:execute).with("SET statement_timeout = '10s'").ordered
+          expect(mock_connection).to have_received(:execute).with("SET statement_timeout = '20m'").ordered
         end
       end
     end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -216,7 +216,7 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
   describe "#max_run_time" do
     context "with default configuration" do
       it "times out after 10 seconds" do
-        expect(job.max_run_time).to eq(10.seconds)
+        expect(job.max_run_time).to eq(60.seconds)
       end
     end
 


### PR DESCRIPTION
Despite the work in #28, we still seem to run into cases where a query hangs and then all future runs of the job fail until the worker is restarted and connections are recreated.

This PR adds a `monitor_statement_timeout_seconds` option which defaults to 10 seconds that will be set as the `statement_timeout` for the Postgres connection.

This PR also makes it so we `disconnect!` connection pools if we hit a `ActiveRecord::StatementInvalid` which might indicate that the connection is bad. Clearing the connections should avoid having a bad connection pollute future runs of the job.

prime: @atsheehan 

[PIMCORE-485]

[PIMCORE-485]: https://salsify.atlassian.net/browse/PIMCORE-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ