### PR TITLE
[PIMCORE-3144] Add support for Rails 7.2 and 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,15 +8,15 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: $SALSIFY_ECR_REPO/ruby_ci:3.0.6
+      - image: $SALSIFY_ECR_REPO/ruby_ci:3.2.8
         <<: *aws-auth
     working_directory: ~/postgres-vacuum-monitor
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-3.0.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-3.0.6-
+            - v1-gems-ruby-3.2.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-3.2.8-
       - run:
           name: Install Gems
           command: |
@@ -25,7 +25,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-3.0.6-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-3.2.8-{{ checksum "postgres-vacuum-monitor.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -94,11 +94,10 @@ workflows:
           matrix:
             parameters:
               gemfile:
-                - gemfiles/activerecord_6_1.gemfile
-                - gemfiles/activerecord_7_0.gemfile
                 - gemfiles/activerecord_7_1.gemfile
+                - gemfiles/activerecord_7_2.gemfile
+                - gemfiles/activerecord_8_0.gemfile
               ruby_version:
-                - 3.0.6
-                - 3.1.4
-                - 3.2.2
-                - 3.3.0
+                - 3.2.8
+                - 3.3.8
+                - 3.4.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   salsify_rubocop: conf/rubocop_rails.yml
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/**/*'

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-appraise 'activerecord_6_1' do
-  gem 'activerecord', '~> 6.1.7.6'
-end
-
-appraise 'activerecord_7_0' do
-  gem 'activerecord', '~> 7.0.8'
-end
-
 appraise 'activerecord_7_1' do
-  gem 'activerecord', '~> 7.1.1'
+  gem 'activerecord', '~> 7.1.5'
+end
+
+appraise 'activerecord_7_2' do
+  gem 'activerecord', '~> 7.2.2'
+end
+
+appraise 'activerecord_8_0' do
+  gem 'activerecord', '~> 8.0.2'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # postgres-vacuum-monitor
 
+## v0.18.0
+- Add support for Rails 7.2 and 8.0.
+- Drop support for Rails 6.1 and 7.0.
+- Drop support for Ruby 3.0 and 3.1.
+
 ## v0.17.0
 - Increased default `monitor_max_run_time_seconds` to 60 seconds.
 - Added `monitor_statement_timeout_seconds` (defaults to 10 seconds) to limit query runtime.

--- a/gemfiles/activerecord_7_1.gemfile
+++ b/gemfiles/activerecord_7_1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.1.1"
+gem "activerecord", "~> 7.1.5"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7_2.gemfile
+++ b/gemfiles/activerecord_7_2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.7.6"
+gem "activerecord", "~> 7.2.2"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_8_0.gemfile
+++ b/gemfiles/activerecord_8_0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.8"
+gem "activerecord", "~> 8.0.2"
 
 gemspec path: "../"

--- a/lib/postgres/vacuum/monitor/version.rb
+++ b/lib/postgres/vacuum/monitor/version.rb
@@ -3,7 +3,7 @@
 module Postgres
   module Vacuum
     module Monitor
-      VERSION = '0.17.0'
+      VERSION = '0.18.0'
     end
   end
 end

--- a/postgres-vacuum-monitor.gemspec
+++ b/postgres-vacuum-monitor.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.42.1'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 7.2'
+  spec.add_dependency 'activerecord', '>= 7.1', '< 8.1'
   spec.add_dependency 'pg', '>= 0.18', '< 2.0'
 end

--- a/spec/postgres/vacuum/jobs/monitor_job_spec.rb
+++ b/spec/postgres/vacuum/jobs/monitor_job_spec.rb
@@ -44,6 +44,8 @@ describe Postgres::Vacuum::Jobs::MonitorJob do
       let(:mock_connection) { double }
 
       before do
+        allow(mock_connection).to receive(:cast_bound_value) { "'#{_1}'" }
+        allow(mock_connection).to receive(:quote) { _1 }
         allow(mock_connection).to receive(:execute).and_return([])
         ActiveRecord::Base.connection_handler.connection_pools.each do |pool|
           allow(pool).to receive(:with_connection).and_yield(mock_connection)


### PR DESCRIPTION
This PR adds support for Rails 7.2 and 8.0 and Ruby 3.4 and drops support for old versions.

prime: @atsheehan 

[PIMCORE-3144]

[PIMCORE-3144]: https://salsify.atlassian.net/browse/PIMCORE-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ